### PR TITLE
Define `best_ahc_ext_lambd`

### DIFF
--- a/cim_optimizer/solve_Ising.py
+++ b/cim_optimizer/solve_Ising.py
@@ -527,6 +527,7 @@ class Ising:
                 elif self.hyperparameters_randomtune == True:
                         best_rand_scaling = 0
                         best_ahc_ext_eps = 0
+                        best_ahc_ext_lambd = 0
                         best_energy = 0
                         for _ in range(15):
                             rand_scaling = np.random.choice(np.array([0.01, 0.1, 1, 10, 100]))


### PR DESCRIPTION
This fixes a corner case where condition in line https://github.com/mcmahon-lab/cim-optimizer/blob/353e18f7de4f77ccaaa0552faee0da50c155baf6/cim_optimizer/solve_Ising.py#L540 is not met and variable `best_ahc_ext_lambd` is not defined, causing an error upon the following `print(...format(...))`.